### PR TITLE
change chart name to admin-console

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: kots-helm
+name: admin-console
 description: A Helm chart for installing kotsadm
 
 # A chart can be either an 'application' or a 'library' chart.
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -6,16 +6,16 @@
   {{- end }}
 {{- end }}
 {{- else if contains "NodePort" .Values.service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "kots-helm.fullname" . }})
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "admin-console.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT
 {{- else if contains "LoadBalancer" .Values.service.type }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "kots-helm.fullname" . }}'
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "kots-helm.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "admin-console.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "admin-console.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
   echo http://$SERVICE_IP:{{ .Values.service.port }}
 {{- else if contains "ClusterIP" .Values.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "kots-helm.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "admin-console.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
   echo "Visit http://127.0.0.1:8080 to use your application"
   kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -1,7 +1,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "kots-helm.name" -}}
+{{- define "admin-console.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
@@ -10,7 +10,7 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
-{{- define "kots-helm.fullname" -}}
+{{- define "admin-console.fullname" -}}
 {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
@@ -26,16 +26,16 @@ If release name contains chart name it will be used as a full name.
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "kots-helm.chart" -}}
+{{- define "admin-console.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
 Common labels
 */}}
-{{- define "kots-helm.labels" -}}
-helm.sh/chart: {{ include "kots-helm.chart" . }}
-{{ include "kots-helm.selectorLabels" . }}
+{{- define "admin-console.labels" -}}
+helm.sh/chart: {{ include "admin-console.chart" . }}
+{{ include "admin-console.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
@@ -47,17 +47,17 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{/*
 Selector labels
 */}}
-{{- define "kots-helm.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "kots-helm.name" . }}
+{{- define "admin-console.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "admin-console.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
 Create the name of the service account to use
 */}}
-{{- define "kots-helm.serviceAccountName" -}}
+{{- define "admin-console.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create }}
-{{- default (include "kots-helm.fullname" .) .Values.serviceAccount.name }}
+{{- default (include "admin-console.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}

--- a/templates/kotsadm-config.yaml
+++ b/templates/kotsadm-config.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    {{- include "kots-helm.labels" . | nindent 4 }}
+    {{- include "admin-console.labels" . | nindent 4 }}
   name: kotsadm-confg
 data:
   initial-app-images-pushed: "false"

--- a/templates/kotsadm-default-configvalues.yaml
+++ b/templates/kotsadm-default-configvalues.yaml
@@ -4,7 +4,7 @@ kind: Secret
 metadata:
   labels:
     kots.io/automation: configvalues
-    {{- include "kots-helm.labels" . | nindent 4 }}
+    {{- include "admin-console.labels" . | nindent 4 }}
   name: kotsadm-default-configvalues
 type: Opaque
 data:

--- a/templates/kotsadm-default-license.yaml
+++ b/templates/kotsadm-default-license.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     kots.io/app: {{ .Values.kotsadm.automation.license.slug }}
     kots.io/automation: license
-    {{- include "kots-helm.labels" . | nindent 4 }}
+    {{- include "admin-console.labels" . | nindent 4 }}
   name: kotsadm-default-license
 type: Opaque
 data:

--- a/templates/kotsadm-deployment.yaml
+++ b/templates/kotsadm-deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    {{- include "kots-helm.labels" . | nindent 4 }}
+    {{- include "admin-console.labels" . | nindent 4 }}
   name: kotsadm
 spec:
   selector:
@@ -18,7 +18,7 @@ spec:
       creationTimestamp: null
       labels:
         app: kotsadm
-        {{- include "kots-helm.labels" . | nindent 8 }}
+        {{- include "admin-console.labels" . | nindent 8 }}
     spec:
       affinity:
         nodeAffinity:

--- a/templates/kotsadm-role.yaml
+++ b/templates/kotsadm-role.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    {{- include "kots-helm.labels" . | nindent 4 }}
+    {{- include "admin-console.labels" . | nindent 4 }}
   name: kotsadm-role
 rules:
 - apiGroups:

--- a/templates/kotsadm-rolebinding.yaml
+++ b/templates/kotsadm-rolebinding.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    {{- include "kots-helm.labels" . | nindent 4 }}
+    {{- include "admin-console.labels" . | nindent 4 }}
   name: kotsadm-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/templates/kotsadm-service.yaml
+++ b/templates/kotsadm-service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    {{- include "kots-helm.labels" . | nindent 4 }}
+    {{- include "admin-console.labels" . | nindent 4 }}
   name: kotsadm
 spec:
   ports:

--- a/templates/kotsadm-serviceaccount.yaml
+++ b/templates/kotsadm-serviceaccount.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    {{- include "kots-helm.labels" . | nindent 4 }}
+    {{- include "admin-console.labels" . | nindent 4 }}
   name: kotsadm

--- a/templates/minio-service.yaml
+++ b/templates/minio-service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    {{- include "kots-helm.labels" . | nindent 4 }}
+    {{- include "admin-console.labels" . | nindent 4 }}
   name: kotsadm-minio
 spec:
   ports:

--- a/templates/minio-statefulset.yaml
+++ b/templates/minio-statefulset.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   labels:
-    {{- include "kots-helm.labels" . | nindent 4 }}
+    {{- include "admin-console.labels" . | nindent 4 }}
   name: kotsadm-minio
 spec:
   selector:
@@ -15,7 +15,7 @@ spec:
         backup.velero.io/backup-volumes: kotsadm-minio,minio-config-dir,minio-cert-dir
       labels:
         app: kotsadm-minio
-        {{- include "kots-helm.labels" . | nindent 8 }}
+        {{- include "admin-console.labels" . | nindent 8 }}
     spec:
       containers:
       - command:
@@ -104,7 +104,7 @@ spec:
   volumeClaimTemplates:
   - metadata:
       labels:
-        {{- include "kots-helm.labels" . | nindent 8 }}
+        {{- include "admin-console.labels" . | nindent 8 }}
       name: kotsadm-minio
     spec:
       accessModes:
@@ -113,5 +113,3 @@ spec:
         requests:
           storage: 4Gi
     status: {}
-status:
-  replicas: 0

--- a/templates/postgres-configmap.yaml
+++ b/templates/postgres-configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    {{- include "kots-helm.labels" . | nindent 4 }}
+    {{- include "admin-console.labels" . | nindent 4 }}
   name: kotsadm-postgres
 data:
   passwd: |-

--- a/templates/postgres-service.yaml
+++ b/templates/postgres-service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    {{- include "kots-helm.labels" . | nindent 4 }}
+    {{- include "admin-console.labels" . | nindent 4 }}
   name: kotsadm-postgres
 spec:
   ports:

--- a/templates/postgres-statefulset.yaml
+++ b/templates/postgres-statefulset.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   labels:
-    {{- include "kots-helm.labels" . | nindent 4 }}
+    {{- include "admin-console.labels" . | nindent 4 }}
   name: kotsadm-postgres
 spec:
   selector:
@@ -13,7 +13,7 @@ spec:
     metadata:
       labels:
         app: kotsadm-postgres
-        {{- include "kots-helm.labels" . | nindent 8 }}
+        {{- include "admin-console.labels" . | nindent 8 }}
     spec:
       containers:
       - env:
@@ -93,7 +93,7 @@ spec:
   volumeClaimTemplates:
   - metadata:
       labels:
-        {{- include "kots-helm.labels" . | nindent 8 }}
+        {{- include "admin-console.labels" . | nindent 8 }}
       name: kotsadm-postgres
     spec:
       accessModes:
@@ -102,5 +102,3 @@ spec:
         requests:
           storage: 1Gi
     status: {}
-status:
-  replicas: 0

--- a/templates/secret-api-cluster-token.yaml
+++ b/templates/secret-api-cluster-token.yaml
@@ -7,7 +7,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   labels:
-    {{- include "kots-helm.labels" . | nindent 4 }}
+    {{- include "admin-console.labels" . | nindent 4 }}
   name: kotsadm-cluster-token
   annotations:
     "helm.sh/resource-policy": "keep"

--- a/templates/secret-api-encryption.yaml
+++ b/templates/secret-api-encryption.yaml
@@ -7,7 +7,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   labels:
-    {{- include "kots-helm.labels" . | nindent 4 }}
+    {{- include "admin-console.labels" . | nindent 4 }}
   name: kotsadm-encryption
 data:
   encryptionKey: {{ $encryptionKey }}

--- a/templates/secret-jwt.yaml
+++ b/templates/secret-jwt.yaml
@@ -7,7 +7,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   labels:
-    {{- include "kots-helm.labels" . | nindent 4 }}
+    {{- include "admin-console.labels" . | nindent 4 }}
   name: kotsadm-session
   annotations:
     "helm.sh/resource-policy": "keep"

--- a/templates/secret-pg.yaml
+++ b/templates/secret-pg.yaml
@@ -11,7 +11,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   labels:
-    {{- include "kots-helm.labels" . | nindent 4 }}
+    {{- include "admin-console.labels" . | nindent 4 }}
   name: kotsadm-postgres
   annotations:
     "helm.sh/resource-policy": "keep"

--- a/templates/secret-s3.yaml
+++ b/templates/secret-s3.yaml
@@ -9,7 +9,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   labels:
-    {{- include "kots-helm.labels" . | nindent 4 }}
+    {{- include "admin-console.labels" . | nindent 4 }}
   name: kotsadm-minio
   annotations:
     "helm.sh/resource-policy": "keep"

--- a/templates/secret-shared-password.yaml
+++ b/templates/secret-shared-password.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   labels:
-    {{- include "kots-helm.labels" . | nindent 4 }}
+    {{- include "admin-console.labels" . | nindent 4 }}
   name: kotsadm-password
 data:
   passwordBcrypt: {{ required "kotsadmPassword is required" .Values.kotsadm.kotsadmPassword | bcrypt | b64enc }}

--- a/templates/tests/test-connection.yaml
+++ b/templates/tests/test-connection.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "{{ include "kots-helm.fullname" . }}-test-connection"
+  name: "{{ include "admin-console.fullname" . }}-test-connection"
   labels:
-    {{- include "kots-helm.labels" . | nindent 4 }}
+    {{- include "admin-console.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": test
 spec:
@@ -11,5 +11,5 @@ spec:
     - name: wget
       image: busybox
       command: ['wget']
-      args: ['{{ include "kots-helm.fullname" . }}:{{ .Values.service.port }}']
+      args: ['{{ include "admin-console.fullname" . }}:{{ .Values.service.port }}']
   restartPolicy: Never

--- a/values.yaml
+++ b/values.yaml
@@ -1,4 +1,4 @@
-# Default values for kots-helm.
+# Default values for admin-console.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 


### PR DESCRIPTION
As title describes..change chart name to admin-console.

Performed successful helm package and deployment of admin console with this new naming.