### PR TITLE
add github workflows for publishing to staging and prod registries

### DIFF
--- a/.github/workflows/publish-production.yaml
+++ b/.github/workflows/publish-production.yaml
@@ -1,0 +1,24 @@
+name: publish-production
+on:
+  push:
+    tags:
+      - "*"
+jobs:
+  package-and-publish:
+    runs-on: 'ubuntu-20.04'
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Install Helm
+      uses: azure/setup-helm@v1
+      with:
+        version: v3.8.1
+    - name: Run Package and Publish
+      env: 
+        HELM_USER: ${{secrets.KOTS_HELM_USER_PROD}}
+        HELM_PASS: ${{secrets.KOTS_HELM_PASS_PROD}}
+      run: |
+        export CHART_NAME=`helm package . | rev | cut -d/ -f1 | rev`
+        echo pushing ${CHART_NAME} to production
+        helm registry login registry.replicated.com  --username $HELM_USER --password $HELM_PASS
+        helm push $CHART_NAME oci://registry.replicated.com/library

--- a/.github/workflows/publish-staging.yaml
+++ b/.github/workflows/publish-staging.yaml
@@ -1,0 +1,24 @@
+name: publish-staging
+on:
+  push:
+    branches:
+      - main
+jobs:
+  package-and-publish:
+    runs-on: 'ubuntu-20.04'
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Install Helm
+      uses: azure/setup-helm@v1
+      with:
+        version: v3.8.1
+    - name: Run Package and Publish
+      env: 
+        HELM_USER: ${{secrets.KOTS_HELM_USER_STAGING}}
+        HELM_PASS: ${{secrets.KOTS_HELM_PASS_STAGING}}
+      run: |
+        export CHART_NAME=`helm package . | rev | cut -d/ -f1 | rev`
+        echo pushing ${CHART_NAME} to staging
+        helm registry login registry.staging.replicated.com  --username $HELM_USER --password $HELM_PASS
+        helm push $CHART_NAME oci://registry.staging.replicated.com/library


### PR DESCRIPTION
1) publish chart to staging on merge to main
2) publish chart to prod on tag creation

The secrets need to be created and am speaking with Chase about this.  I have tested both work flows and both work when proper user/pass provided.
1) prod test run: https://github.com/replicatedhq/kots-helm/runs/6492270041?check_suite_focus=true
2) staging test run: https://github.com/replicatedhq/kots-helm/runs/6492270008?check_suite_focus=true