### PR TITLE
Helm chart versions match kots versions

### DIFF
--- a/.github/workflows/publish-production.yaml
+++ b/.github/workflows/publish-production.yaml
@@ -2,11 +2,18 @@ name: publish-production
 on:
   push:
     tags:
-      - "*"
+    - 'v[0-9]+.[0-9]+.[0-9]+'
+    - 'v[0-9]+.[0-9]+.[0-9]+\-build\.[0-9]+'
+
 jobs:
   package-and-publish:
     runs-on: 'ubuntu-20.04'
     steps:
+    - name: Get tag
+      id: tag
+      uses: dawidd6/action-get-tag@v1
+      with:
+        strip_v: true
     - name: Checkout
       uses: actions/checkout@v2
     - name: Install Helm
@@ -17,7 +24,23 @@ jobs:
       env: 
         HELM_USER: ${{secrets.KOTS_HELM_USER_PROD}}
         HELM_PASS: ${{secrets.KOTS_HELM_PASS_PROD}}
+        CHART_VERSION: ${{steps.tag.outputs.tag}}
       run: |
+        export KOTS_VERSION=${CHART_VERSION%-*}
+        export KOTS_TAG=v${KOTS_VERSION}
+
+        export LATEST_KOTS_TAG=`curl https://api.github.com/repos/replicatedhq/kots/releases/latest | jq -r .tag_name`
+        if [[ "$KOTS_TAG" != "$LATEST_KOTS_TAG" ]]; then
+          echo "Latest KOTS tag is ${LATEST_KOTS_TAG}, but this tag is ${KOTS_TAG}"
+          exit -1
+        fi
+
+        curl -O -L https://raw.githubusercontent.com/replicatedhq/kots/${KOTS_TAG}/.image.env
+        export $(cat .image.env | sed 's/#.*//g' | xargs)
+        envsubst < Chart.yaml.tmpl > Chart.yaml
+        envsubst < values.yaml.tmpl > values.yaml
+        rm -f *.tmpl
+
         export CHART_NAME=`helm package . | rev | cut -d/ -f1 | rev`
         echo pushing ${CHART_NAME} to production
         helm registry login registry.replicated.com  --username $HELM_USER --password $HELM_PASS

--- a/.github/workflows/publish-staging.yaml
+++ b/.github/workflows/publish-staging.yaml
@@ -1,12 +1,19 @@
 name: publish-staging
 on:
   push:
-    branches:
-      - main
+    tags:
+    - 'v[0-9]+.[0-9]+.[0-9]+\-alpha'
+    - 'v[0-9]+.[0-9]+.[0-9]+\-alpha\.[0-9]+'
+
 jobs:
   package-and-publish:
     runs-on: 'ubuntu-20.04'
     steps:
+    - name: Get tag
+      id: tag
+      uses: dawidd6/action-get-tag@v1
+      with:
+        strip_v: true
     - name: Checkout
       uses: actions/checkout@v2
     - name: Install Helm
@@ -17,7 +24,17 @@ jobs:
       env: 
         HELM_USER: ${{secrets.KOTS_HELM_USER_STAGING}}
         HELM_PASS: ${{secrets.KOTS_HELM_PASS_STAGING}}
+        CHART_VERSION: ${{steps.tag.outputs.tag}}
       run: |
+        export KOTS_VERSION=${CHART_VERSION%-*}
+        export KOTS_TAG=v${KOTS_VERSION}
+
+        curl -O -L https://raw.githubusercontent.com/replicatedhq/kots/${KOTS_TAG}/.image.env
+        export $(cat .image.env | sed 's/#.*//g' | xargs)
+        envsubst < Chart.yaml.tmpl > Chart.yaml
+        envsubst < values.yaml.tmpl > values.yaml
+        rm -f *.tmpl
+
         export CHART_NAME=`helm package . | rev | cut -d/ -f1 | rev`
         echo pushing ${CHART_NAME} to staging
         helm registry login registry.staging.replicated.com  --username $HELM_USER --password $HELM_PASS

--- a/.helmignore
+++ b/.helmignore
@@ -1,0 +1,3 @@
+build-local.sh
+/*.yaml.tmpl
+/.image.env

--- a/Chart.yaml.tmpl
+++ b/Chart.yaml.tmpl
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: admin-console
-description: A Helm chart for installing kotsadm
+description: A Helm chart for installing KOTS Admin Conole
 
 # A chart can be either an 'application' or a 'library' chart.
 #
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: ${CHART_VERSION}
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "alpha"
+appVersion: ${KOTS_VERSION}

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This helm chart allows installing a Replicated kots application by installing ko
 ## UI based install 
 
 ```shell
-    helm upgrade --install [RELEASE_NAME] . --namespace [NAMESPACE] --create-namespace --set kotsadm.kotsadmPassword=[KOTSADM_PASSWORD]
+    helm upgrade --install [RELEASE_NAME] . --namespace [NAMESPACE] --create-namespace --set adminConsole.password=[KOTSADM_PASSWORD]
     kubectl port-forward -n [NAMESPACE] svc/kotsadm 8800:3000
 ```
 
@@ -20,27 +20,36 @@ This helm chart allows installing a Replicated kots application by installing ko
 
 If you want to automatically install the kots license, you can do so by setting the following 2 values:
 
-* `kotsadm.automation.license.slug`: The application slug for the application you're installing. For example: `sentry-pro`
-* `kotsadm.automation.license.data`: The license yaml content.
+* `adminConsole.automation.license.slug`: The application slug for the application you're installing. For example: `sentry-pro`
+* `adminConsole.automation.license.data`: The license yaml content.
 
 ```shell
     helm upgrade --install [RELEASE_NAME] . --namespace [NAMESPACE] --create-namespace \
-        --set kotsadm.kotsadmPassword=[KOTSADM_PASSWORD] \
-        --set kotsadm.automation.license.slug=[APP_SLUG] \
-        --set kotsadm.automation.license.data="$(cat [PATH_TO_LICENSE_YAML])"
+        --set adminConsole.password=[KOTSADM_PASSWORD] \
+        --set adminConsole.automation.license.slug=[APP_SLUG] \
+        --set adminConsole.automation.license.data="$(cat [PATH_TO_LICENSE_YAML])"
     kubectl port-forward -n [NAMESPACE] svc/kotsadm 8800:3000
 ```
 
 If you want to skip pre-flights, you can do so by setting the following value:
-* `kotsadm.automation.skipPreflights` (default: `false`)
+* `adminConsole.automation.skipPreflights` (default: `false`)
 
-If you want to specify ConfigValues, you can do so by setting the `kotsadm.automation.config.values`:
+If you want to specify ConfigValues, you can do so by setting the `adminConsole.automation.config.values`:
 
 ```shell
     helm upgrade --install [RELEASE_NAME] . --namespace [NAMESPACE] --create-namespace \
-        --set kotsadm.kotsadmPassword=[KOTSADM_PASSWORD] \
-        --set kotsadm.automation.license.slug=[APP_SLUG] \
-        --set kotsadm.automation.license.data="$(cat [PATH_TO_LICENSE_YAML])" \
-        --set kotsadm.automation.config.values="$(cat [PATH_TO_CONFIG_YAML])"
+        --set adminConsole.password=[KOTSADM_PASSWORD] \
+        --set adminConsole.automation.license.slug=[APP_SLUG] \
+        --set adminConsole.automation.license.data="$(cat [PATH_TO_LICENSE_YAML])" \
+        --set adminConsole.automation.config.values="$(cat [PATH_TO_CONFIG_YAML])"
     kubectl port-forward -n [NAMESPACE] svc/kotsadm 8800:3000
+```
+
+## Local dev
+
+Run build-local.sh script located in the root directory of this repository to create a chart.
+The input parameter is the kots version to package
+
+```
+./build-local.sh 1.75.0
 ```

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,33 @@
+# Creating a staging release
+
+Staging Helm chart of this repo can be created by pushing a version tag with `-alpha` pre-release value.
+The version of the chart must match some version of KOTS.
+For example:
+
+```shell
+    git tag v1.76.0-alpha
+```
+
+Multiple versions of the chart can be created for the same version of KOTS by adding a numeric identifier.
+For example:
+
+```shell
+    git tag v1.76.0-alpha.2
+```
+
+# Creating a production release
+
+Staging Helm chart of this repo can be created by pushing a version tag.
+The version of the chart must match the latest version of KOTS.
+For example:
+
+```shell
+    git tag v1.76.0
+```
+
+Multiple versions of the chart can be created for the same version of KOTS by build suffix with a numeric identifier.
+For example:
+
+```shell
+    git tag v1.76.0-build.2
+```

--- a/build-local.sh
+++ b/build-local.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e
+
+export CURRENT_USER=`id -u -n`
+export KOTS_VERSION=$1
+export KOTS_TAG=v${KOTS_VERSION}
+export CHART_VERSION=${KOTS_VERSION}
+
+curl -O -L https://raw.githubusercontent.com/replicatedhq/kots/${KOTS_TAG}/.image.env
+export $(cat .image.env | sed 's/#.*//g' | xargs)
+envsubst < Chart.yaml.tmpl > Chart.yaml
+envsubst < values.yaml.tmpl > values.yaml
+
+export CHART_NAME=`helm package . | rev | cut -d/ -f1 | rev`
+helm push $CHART_NAME oci://ttl.sh/${CURRENT_USER}
+
+rm -f Chart.yaml values.yaml .image.env

--- a/templates/kotsadm-config.yaml
+++ b/templates/kotsadm-config.yaml
@@ -8,5 +8,5 @@ data:
   initial-app-images-pushed: "false"
   minio-enabled-snapshots: "false"
   registry-is-read-only: "false"
-  skip-preflights: {{ .Values.kotsadm.automation.skipPreflights | quote }}
+  skip-preflights: {{ .Values.adminConsole.automation.skipPreflights | quote }}
 

--- a/templates/kotsadm-default-configvalues.yaml
+++ b/templates/kotsadm-default-configvalues.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.kotsadm.automation.config.values }}
+{{ if .Values.adminConsole.automation.config.values }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,5 +8,5 @@ metadata:
   name: kotsadm-default-configvalues
 type: Opaque
 data:
-  configvalues: {{ .Values.kotsadm.automation.config.values | b64enc }}
+  configvalues: {{ .Values.adminConsole.automation.config.values | b64enc }}
 {{ end }}

--- a/templates/kotsadm-default-license.yaml
+++ b/templates/kotsadm-default-license.yaml
@@ -1,15 +1,15 @@
-{{ if .Values.kotsadm.automation.license.slug }}
+{{ if .Values.adminConsole.automation.license.slug }}
 apiVersion: v1
 kind: Secret
 metadata:
   annotations:
     kots.io/airgap: "false"
   labels:
-    kots.io/app: {{ .Values.kotsadm.automation.license.slug }}
+    kots.io/app: {{ .Values.adminConsole.automation.license.slug }}
     kots.io/automation: license
     {{- include "admin-console.labels" . | nindent 4 }}
   name: kotsadm-default-license
 type: Opaque
 data:
-  license: {{ .Values.kotsadm.automation.license.data | b64enc }}
+  license: {{ .Values.adminConsole.automation.license.data | b64enc }}
 {{ end }}

--- a/templates/kotsadm-deployment.yaml
+++ b/templates/kotsadm-deployment.yaml
@@ -97,8 +97,8 @@ spec:
           value: kotsadm-postgres,kotsadm-minio,kotsadm-api-node
         - name: IS_HELM_MANAGED
           value: "true"
-        image: kotsadm/kotsadm:alpha
-        imagePullPolicy: Always
+        image: {{ .Values.adminConsole.images.kotsadm }}
+        imagePullPolicy: IfNotPresent
         name: kotsadm
         ports:
         - containerPort: 3000
@@ -138,7 +138,7 @@ spec:
             secretKeyRef:
               key: uri
               name: kotsadm-postgres
-        image: kotsadm/kotsadm-migrations:v1.57.0
+        image: {{ .Values.adminConsole.images.migrations }}
         imagePullPolicy: IfNotPresent
         name: schemahero-plan
         resources:
@@ -163,7 +163,7 @@ spec:
             secretKeyRef:
               key: uri
               name: kotsadm-postgres
-        image: kotsadm/kotsadm-migrations:v1.57.0
+        image: {{ .Values.adminConsole.images.migrations }}
         imagePullPolicy: IfNotPresent
         name: schemahero-apply
         resources:
@@ -184,7 +184,7 @@ spec:
             secretKeyRef:
               key: password
               name: kotsadm-postgres
-        image: kotsadm/kotsadm:alpha
+        image: {{ .Values.adminConsole.images.kotsadm }}
         imagePullPolicy: IfNotPresent
         name: restore-db
         resources:
@@ -218,7 +218,7 @@ spec:
               name: kotsadm-minio
         - name: S3_BUCKET_ENDPOINT
           value: "true"
-        image: kotsadm/kotsadm:alpha
+        image: {{ .Values.adminConsole.images.kotsadm }}
         imagePullPolicy: IfNotPresent
         name: restore-s3
         resources:

--- a/templates/minio-statefulset.yaml
+++ b/templates/minio-statefulset.yaml
@@ -38,7 +38,7 @@ spec:
           value: "on"
         - name: MINIO_UPDATE
           value: "off"
-        image: minio/minio:RELEASE.2021-10-02T16-31-05Z
+        image: {{ .Values.adminConsole.images.minio }}
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/templates/postgres-statefulset.yaml
+++ b/templates/postgres-statefulset.yaml
@@ -28,7 +28,7 @@ spec:
               name: kotsadm-postgres
         - name: POSTGRES_DB
           value: kotsadm
-        image: postgres:10.18-alpine
+        image: {{ .Values.adminConsole.images.postgres }}
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:

--- a/templates/secret-shared-password.yaml
+++ b/templates/secret-shared-password.yaml
@@ -6,5 +6,5 @@ metadata:
     {{- include "admin-console.labels" . | nindent 4 }}
   name: kotsadm-password
 data:
-  passwordBcrypt: {{ default $adminPassword .Values.kotsadm.kotsadmPassword | bcrypt | b64enc }}
-  passwordB64: {{ default $adminPassword .Values.kotsadm.kotsadmPassword | b64enc }}
+  passwordBcrypt: {{ default $adminPassword .Values.adminConsole.password | bcrypt | b64enc }}
+  passwordB64: {{ default $adminPassword .Values.adminConsole.password | b64enc }}

--- a/values.yaml.tmpl
+++ b/values.yaml.tmpl
@@ -2,8 +2,8 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-kotsadm:
-  kotsadmPassword: ""
+adminConsole:
+  password: ""
   automation:
     license:
       slug: ""
@@ -11,6 +11,11 @@ kotsadm:
     skipPreflights: false
     config:
       values: ""
+    images:
+      kotsadm: kotsadm/kotsadm:${KOTS_TAG}
+      migrations: kotsadm/kotsadm-migrations:${KOTS_TAG}
+      minio: minio/minio:${MINIO_TAG}
+      postgres: postgres:${POSTGRES_ALPINE_TAG}
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
- Removes hardcoded images.  Images are now taken from kots repo's image manifest that matches the tagged version.
- Staging releases are now created with `alpha` tags instead of merges to main branch
- Production releases are created with non-`alpha` tags