### PR TITLE
use service port value

### DIFF
--- a/templates/kotsadm-service.yaml
+++ b/templates/kotsadm-service.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   ports:
   - name: http
-    port: 3000
+    port: {{ .Values.service.port }}
     targetPort: 3000
   selector:
     app: kotsadm


### PR DESCRIPTION
Set default port to 80.  This was already done in the values yaml, we just needed to use the value

fixes:
https://app.shortcut.com/replicated/story/50965/admin-console-service-should-default-to-listening-on-80-not-3000