### PR TITLE
Don't override existing password with default on upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This helm chart allows installing a Replicated kots application by installing ko
 ## UI based install 
 
 ```shell
-    helm upgrade --install [RELEASE_NAME] . --namespace [NAMESPACE] --create-namespace --set adminConsole.password=[KOTSADM_PASSWORD]
+    helm upgrade --install [RELEASE_NAME] . --namespace [NAMESPACE] --create-namespace --set password=[KOTSADM_PASSWORD]
     kubectl port-forward -n [NAMESPACE] svc/kotsadm 8800:3000
 ```
 
@@ -20,28 +20,28 @@ This helm chart allows installing a Replicated kots application by installing ko
 
 If you want to automatically install the kots license, you can do so by setting the following 2 values:
 
-* `adminConsole.automation.license.slug`: The application slug for the application you're installing. For example: `sentry-pro`
-* `adminConsole.automation.license.data`: The license yaml content.
+* `automation.license.slug`: The application slug for the application you're installing. For example: `sentry-pro`
+* `automation.license.data`: The license yaml content.
 
 ```shell
     helm upgrade --install [RELEASE_NAME] . --namespace [NAMESPACE] --create-namespace \
-        --set adminConsole.password=[KOTSADM_PASSWORD] \
-        --set adminConsole.automation.license.slug=[APP_SLUG] \
-        --set adminConsole.automation.license.data="$(cat [PATH_TO_LICENSE_YAML])"
+        --set password=[KOTSADM_PASSWORD] \
+        --set automation.license.slug=[APP_SLUG] \
+        --set automation.license.data="$(cat [PATH_TO_LICENSE_YAML])"
     kubectl port-forward -n [NAMESPACE] svc/kotsadm 8800:3000
 ```
 
 If you want to skip pre-flights, you can do so by setting the following value:
-* `adminConsole.automation.skipPreflights` (default: `false`)
+* `automation.skipPreflights` (default: `false`)
 
-If you want to specify ConfigValues, you can do so by setting the `adminConsole.automation.config.values`:
+If you want to specify ConfigValues, you can do so by setting the `automation.config.values`:
 
 ```shell
     helm upgrade --install [RELEASE_NAME] . --namespace [NAMESPACE] --create-namespace \
-        --set adminConsole.password=[KOTSADM_PASSWORD] \
-        --set adminConsole.automation.license.slug=[APP_SLUG] \
-        --set adminConsole.automation.license.data="$(cat [PATH_TO_LICENSE_YAML])" \
-        --set adminConsole.automation.config.values="$(cat [PATH_TO_CONFIG_YAML])"
+        --set password=[KOTSADM_PASSWORD] \
+        --set automation.license.slug=[APP_SLUG] \
+        --set automation.license.data="$(cat [PATH_TO_LICENSE_YAML])" \
+        --set automation.config.values="$(cat [PATH_TO_CONFIG_YAML])"
     kubectl port-forward -n [NAMESPACE] svc/kotsadm 8800:3000
 ```
 

--- a/templates/secret-shared-password.yaml
+++ b/templates/secret-shared-password.yaml
@@ -1,3 +1,15 @@
+# Default password is "password".
+# Password specified in values or on command line overrides password currently in secret.
+# If no password is specified, password in secret is preserved.
+{{- $passwordBcrypt := "password" | bcrypt | b64enc }}
+{{- if ne .Values.password "" }}
+{{-   $passwordBcrypt = .Values.password | bcrypt | b64enc  }}
+{{- else -}}
+{{-   $secret := (lookup "v1" "Secret" .Release.Namespace "kotsadm-password") }}
+{{-   if $secret }}
+{{-     $passwordBcrypt = index $secret.data "passwordBcrypt" }}
+{{-   end }}
+{{- end }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -5,4 +17,4 @@ metadata:
     {{- include "admin-console.labels" . | nindent 4 }}
   name: kotsadm-password
 data:
-  passwordBcrypt: {{ default "password" .Values.password | bcrypt | b64enc }}
+  passwordBcrypt: {{ $passwordBcrypt }}


### PR DESCRIPTION
Current password is preserved unless a password value is specified in the upgrade command

```
helm upgrade admin-console oci://registry.replicated.com/library/admin-console --set password=password123
```