### PR TITLE
Allow specifying Service nodePort

### DIFF
--- a/templates/kotsadm-service.yaml
+++ b/templates/kotsadm-service.yaml
@@ -9,6 +9,9 @@ spec:
   - name: http
     port: {{ .Values.service.port }}
     targetPort: 3000
+{{- if (and (eq .Values.service.type "NodePort") ( .Values.service.nodePort)) }}
+    nodePort: {{ .Values.service.nodePort }}
+{{- end}}
   selector:
     app: kotsadm
   type: {{ .Values.service.type }}


### PR DESCRIPTION
Allows for specifying `.service.nodePort` in the values file for setting the kotsadm Service nodePort.