### PR TITLE
feat: move the affinity settings to the values file

### DIFF
--- a/templates/kotsadm-deployment.yaml
+++ b/templates/kotsadm-deployment.yaml
@@ -20,19 +20,10 @@ spec:
         app: kotsadm
         {{- include "admin-console.labels" . | nindent 8 }}
     spec:
+      {{- with .Values.affinity }}
       affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: kubernetes.io/os
-                operator: In
-                values:
-                - linux
-              - key: kubernetes.io/arch
-                operator: NotIn
-                values:
-                - arm64
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - env:
         - name: SHARED_PASSWORD_BCRYPT

--- a/values.yaml.tmpl
+++ b/values.yaml.tmpl
@@ -33,20 +33,6 @@ serviceAccount:
 
 podAnnotations: {}
 
-affinity:
-  nodeAffinity:
-    requiredDuringSchedulingIgnoredDuringExecution:
-      nodeSelectorTerms:
-        - matchExpressions:
-          - key: kubernetes.io/os
-            operator: In
-            values:
-              - linux
-          - key: kubernetes.io/arch
-            operator: NotIn
-            values:
-              - arm64
-
 podSecurityContext: {}
   # fsGroup: 2000
 
@@ -101,4 +87,16 @@ nodeSelector: {}
 
 tolerations: []
 
-affinity: {}
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
+          - key: kubernetes.io/os
+            operator: In
+            values:
+              - linux
+          - key: kubernetes.io/arch
+            operator: NotIn
+            values:
+              - arm64

--- a/values.yaml.tmpl
+++ b/values.yaml.tmpl
@@ -33,6 +33,20 @@ serviceAccount:
 
 podAnnotations: {}
 
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
+          - key: kubernetes.io/os
+            operator: In
+            values:
+              - linux
+          - key: kubernetes.io/arch
+            operator: NotIn
+            values:
+              - arm64
+
 podSecurityContext: {}
   # fsGroup: 2000
 


### PR DESCRIPTION
During development it is possible to run kots on an arm mac. While not the default or supported, this change would allow me to override the configuration so I can do this.