### PR TITLE
bug: indent application yaml file inside config map

### DIFF
--- a/templates/kotsadm-application.yaml
+++ b/templates/kotsadm-application.yaml
@@ -4,5 +4,6 @@ kind: ConfigMap
 metadata:
   name: kotsadm-application-metadata
 data:
-  application.yaml: "{{- .Values.kotsApplication }}"
+  application.yaml: |
+{{ indent 4 .Values.kotsApplication }}
 {{- end }}


### PR DESCRIPTION
using indent to make sure the application.yaml is placed where it should be inside the values.yaml used to install the kots helm chart.