### PR TITLE
ensure the nodeport is named admin-console

### DIFF
--- a/templates/kotsadm-service.yaml
+++ b/templates/kotsadm-service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   labels:
     {{- include "admin-console.labels" . | nindent 4 }}
-  name: kotsadm-nodeport
+  name: admin-console
 spec:
   ports:
   - name: http


### PR DESCRIPTION
kotsadm relies on this to generate the node join command