### PR TITLE
fix invalid encryption key generation

### DIFF
--- a/templates/secret-api-encryption.yaml
+++ b/templates/secret-api-encryption.yaml
@@ -1,4 +1,4 @@
-{{- $encryptionKey := randAlphaNum 24 | b64enc | quote }}
+{{- $encryptionKey := randAlphaNum 36 | b64enc | quote }}
 {{- $secret := (lookup "v1" "Secret" .Release.Namespace "kotsadm-encryption") }}
 {{- if $secret }}
 {{- $encryptionKey = index $secret.data "encryptionKey" }}
@@ -9,6 +9,6 @@ metadata:
   labels:
     {{- include "admin-console.labels" . | nindent 4 }}
   name: kotsadm-encryption
-data:
+stringData:
   encryptionKey: {{ $encryptionKey }}
 


### PR DESCRIPTION
fixes the templating in the `kotsadm-encryption` secret so that the encryption key generated is valid