### PR TITLE
Base64 decode encryption key when reading it from existing secret

### DIFF
--- a/templates/secret-api-encryption.yaml
+++ b/templates/secret-api-encryption.yaml
@@ -1,7 +1,7 @@
 {{- $encryptionKey := randAlphaNum 36 | b64enc | quote }}
 {{- $secret := (lookup "v1" "Secret" .Release.Namespace "kotsadm-encryption") }}
 {{- if $secret }}
-{{- $encryptionKey = index $secret.data "encryptionKey" }}
+{{- $encryptionKey = index $secret.data "encryptionKey" | b64dec }}
 {{- end -}}
 apiVersion: v1
 kind: Secret
@@ -11,4 +11,3 @@ metadata:
   name: kotsadm-encryption
 stringData:
   encryptionKey: {{ $encryptionKey }}
-


### PR DESCRIPTION
Fixes an issue where the encryption key gets base64 encoded every time the Helm chart gets upgraded.