### PR TITLE
Make password secret optional

### DIFF
--- a/templates/abandon-resources-hook.yaml
+++ b/templates/abandon-resources-hook.yaml
@@ -25,6 +25,11 @@ spec:
           if kubectl get configmap kotsadm-application-metadata -n {{ .Release.Namespace }} -o jsonpath='{.metadata.labels.app\.kubernetes\.io/managed-by}' | grep -q "Helm"; then
             kubectl annotate configmap kotsadm-application-metadata -n {{ .Release.Namespace }} helm.sh/resource-policy=keep
           fi
+          {{- if .Values.passwordSecretRef }}
+          if kubectl get secret kotsadm-password -n {{ .Release.Namespace }} -o jsonpath='{.metadata.labels.app\.kubernetes\.io/managed-by}' | grep -q "Helm"; then
+            kubectl annotate secret kotsadm-password -n {{ .Release.Namespace }} helm.sh/resource-policy=keep
+          fi
+          {{- end }}
         image: {{ .Values.images.kotsadm }}
         imagePullPolicy: IfNotPresent
         name: abandon-resources

--- a/templates/kotsadm-statefulset.yaml
+++ b/templates/kotsadm-statefulset.yaml
@@ -32,6 +32,10 @@ spec:
 {{- with .Values.passwordSecretRef }}
               key: {{ .key }}
               name: {{ .name }}
+        - name: SHARED_PASSWORD_SECRET_NAME
+          value: {{ .name }}
+        - name: SHARED_PASSWORD_SECRET_KEY
+          value: {{ .key }}
 {{- end }}
 {{- else }}
               key: passwordBcrypt

--- a/templates/kotsadm-statefulset.yaml
+++ b/templates/kotsadm-statefulset.yaml
@@ -28,8 +28,15 @@ spec:
         - name: SHARED_PASSWORD_BCRYPT
           valueFrom:
             secretKeyRef:
+{{- if .Values.passwordSecretRef }}
+{{- with .Values.passwordSecretRef }}
+              key: {{ .key }}
+              name: {{ .name }}
+{{- end }}
+{{- else }}
               key: passwordBcrypt
               name: kotsadm-password
+{{- end }} 
         - name: AUTO_CREATE_CLUSTER_TOKEN
           valueFrom:
             secretKeyRef:
@@ -40,7 +47,7 @@ spec:
             secretKeyRef:
               key: key
               name: kotsadm-session
-{{ if not .Values.isHelmManaged }}
+{{- if not .Values.isHelmManaged }}
         - name: RQLITE_PASSWORD
           valueFrom:
             secretKeyRef:
@@ -51,7 +58,7 @@ spec:
             secretKeyRef:
               key: uri
               name: kotsadm-rqlite
-{{ end }}
+{{- end }}
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -65,14 +72,14 @@ spec:
           value: http://kotsadm.{{ .Release.Namespace }}.svc.cluster.local:3000
         - name: API_ADVERTISE_ENDPOINT
           value: http://localhost:8800
-{{ if .Values.embeddedClusterID }}
+{{- if .Values.embeddedClusterID }}
         - name: EMBEDDED_CLUSTER_ID
           value: {{ .Values.embeddedClusterID | quote }}
-{{ end }}
-{{ if .Values.embeddedClusterVersion }}
+{{- end }}
+{{- if .Values.embeddedClusterVersion }}
         - name: EMBEDDED_CLUSTER_VERSION
           value: {{ .Values.embeddedClusterVersion | quote }}
-{{ end }}
+{{- end }}
         - name: HTTP_PROXY
         - name: HTTPS_PROXY
         - name: NO_PROXY

--- a/templates/secret-shared-password.yaml
+++ b/templates/secret-shared-password.yaml
@@ -1,6 +1,8 @@
 # Default password is "password".
 # Password specified in values or on command line overrides password currently in secret.
 # If no password is specified, password in secret is preserved.
+# If createPasswordSecret is `false` this will be skipped entirely (useful for EC)
+{{- if .Values.createPasswordSecret }}
 {{- $passwordBcrypt := "password" | bcrypt | b64enc }}
 {{- if ne .Values.password "" }}
 {{-   $passwordBcrypt = .Values.password | bcrypt | b64enc  }}
@@ -18,3 +20,4 @@ metadata:
   name: kotsadm-password
 data:
   passwordBcrypt: {{ $passwordBcrypt }}
+{{- end }}

--- a/templates/secret-shared-password.yaml
+++ b/templates/secret-shared-password.yaml
@@ -1,8 +1,8 @@
 # Default password is "password".
 # Password specified in values or on command line overrides password currently in secret.
 # If no password is specified, password in secret is preserved.
-# If createPasswordSecret is `false` this will be skipped entirely (useful for EC)
-{{- if .Values.createPasswordSecret }}
+# If passwordSecretRef is defined this will be skipped entirely (useful for EC)
+{{- if .Values.passwordSecretRef }}
 {{- $passwordBcrypt := "password" | bcrypt | b64enc }}
 {{- if ne .Values.password "" }}
 {{-   $passwordBcrypt = .Values.password | bcrypt | b64enc  }}

--- a/templates/secret-shared-password.yaml
+++ b/templates/secret-shared-password.yaml
@@ -2,7 +2,7 @@
 # Password specified in values or on command line overrides password currently in secret.
 # If no password is specified, password in secret is preserved.
 # If passwordSecretRef is defined this will be skipped entirely (useful for EC)
-{{- if .Values.passwordSecretRef }}
+{{- if not .Values.passwordSecretRef }}
 {{- $passwordBcrypt := "password" | bcrypt | b64enc }}
 {{- if ne .Values.password "" }}
 {{-   $passwordBcrypt = .Values.password | bcrypt | b64enc  }}

--- a/values.yaml.tmpl
+++ b/values.yaml.tmpl
@@ -8,6 +8,7 @@ images:
   rqlite: ${KOTSADM_REGISTRY}/rqlite:${RQLITE_TAG}
   kurlProxy: ${KOTSADM_REGISTRY}/kurl-proxy:${KOTS_TAG}
 password: ""
+createPasswordSecret: true
 minimalRBAC: true
 isHelmManaged: true
 embeddedClusterID: ""

--- a/values.yaml.tmpl
+++ b/values.yaml.tmpl
@@ -8,7 +8,7 @@ images:
   rqlite: ${KOTSADM_REGISTRY}/rqlite:${RQLITE_TAG}
   kurlProxy: ${KOTSADM_REGISTRY}/kurl-proxy:${KOTS_TAG}
 password: ""
-createPasswordSecret: true
+passwordSecretRef: {}
 minimalRBAC: true
 isHelmManaged: true
 embeddedClusterID: ""


### PR DESCRIPTION
new value: `passwordSecretRef` takes a secret ref i.e: `map[key, name]` to tell kots what secret to use instead of the default. 

if set, it overrides password secret generation 