### PR TITLE
add extraEnv value to allow setting additional environment variables

### DIFF
--- a/templates/kotsadm-statefulset.yaml
+++ b/templates/kotsadm-statefulset.yaml
@@ -25,6 +25,9 @@ spec:
       {{- end }}
       containers:
       - env:
+        {{- with .Values.extraEnv }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         - name: SHARED_PASSWORD_BCRYPT
           valueFrom:
             secretKeyRef:
@@ -84,10 +87,6 @@ spec:
         - name: EMBEDDED_CLUSTER_VERSION
           value: {{ .Values.embeddedClusterVersion | quote }}
 {{- end }}
-        - name: HTTP_PROXY
-        - name: HTTPS_PROXY
-        - name: NO_PROXY
-          value: kotsadm-rqlite,kotsadm-api-node
         - name: IS_HELM_MANAGED
           value: {{ .Values.isHelmManaged | quote }}
         - name: DISABLE_OUTBOUND_CONNECTIONS

--- a/values.yaml.tmpl
+++ b/values.yaml.tmpl
@@ -65,6 +65,10 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+extraEnv: []
+#  - name: HTTP_PROXY
+#    value: http://proxy.example.com
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
This PR adds an `extraEnv` value to the KOTS helm chart to allow setting additional environment variables on the `kotsadm` StatefulSet (ex: for a proxy).