### PR TITLE
Revert "set IS_HA env var based on helm chart value"

### DIFF
--- a/templates/kotsadm-deployment.yaml
+++ b/templates/kotsadm-deployment.yaml
@@ -89,8 +89,6 @@ spec:
 {{- end }}
         - name: DISABLE_OUTBOUND_CONNECTIONS
           value: {{ .Values.isAirgap | quote }}
-        - name: IS_HA
-          value: {{ .Values.isHA | quote }}
         image: {{ .Values.images.kotsadm }}
         imagePullPolicy: IfNotPresent
         name: kotsadm


### PR DESCRIPTION
Reverts replicatedhq/kots-helm#50

We don't otherwise restart kots at this point, and avoiding it would be good