### PR TITLE
Allow running on arm64 nodes

### DIFF
--- a/values.yaml.tmpl
+++ b/values.yaml.tmpl
@@ -102,8 +102,9 @@ affinity:
             values:
               - linux
           - key: kubernetes.io/arch
-            operator: NotIn
+            operator: In
             values:
+              - amd64
               - arm64
 
 kurlProxy:


### PR DESCRIPTION
This is to support running a local EC dev env (on Mac)