### PR TITLE
fix(proxy): use fqdn for kotsadm-rqlite address

### DIFF
--- a/templates/secret-rqlite.yaml
+++ b/templates/secret-rqlite.yaml
@@ -3,7 +3,7 @@
 {{- if $secret }}
 {{- $rqlitePassword = index $secret.data "password" | b64dec }}
 {{- end -}}
-{{- $rqliteUri := printf "http://kotsadm:%s@kotsadm-rqlite:4001?timeout=120&disableClusterDiscovery=true" $rqlitePassword }}
+{{- $rqliteUri := printf "http://kotsadm:%s@kotsadm-rqlite.%s.svc.cluster.local:4001?timeout=120&disableClusterDiscovery=true" $rqlitePassword .Release.Namespace }}
 {{- $rqliteAuthConfig := printf `[{"username": "kotsadm", "password": "%s", "perms": ["all"]}, {"username": "*", "perms": ["status", "ready"]}]` $rqlitePassword }}
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
When setting NO_PROXY env var to include .cluster.local this will not work with the shorthand dns.