### PR TITLE
fix: use fqdn for kotsadm-minio for proxy support

### DIFF
--- a/templates/migrate-s3-hook.yaml
+++ b/templates/migrate-s3-hook.yaml
@@ -37,7 +37,7 @@ spec:
         - s3-to-rqlite
         env:
         - name: S3_ENDPOINT
-          value: http://kotsadm-minio:9000
+          value: http://kotsadm-minio.{{ .Release.Namespace }}.svc.cluster.local:9000
         - name: S3_BUCKET_NAME
           value: kotsadm
         - name: S3_ACCESS_KEY_ID


### PR DESCRIPTION
When setting NO_PROXY env var to include .cluster.local this will not work with the shorthand dns.