### PR TITLE
chore: rename extra-cas to private-cas

### DIFF
--- a/templates/configmap-private-cas.yaml
+++ b/templates/configmap-private-cas.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: kotsadm-extra-ca
-{{- if (not (empty .Values.extraCAs)) }}
+  name: kotsadm-private-cas
+{{- if (not (empty .Values.privateCAs)) }}
 data:
-{{- range $key, $value := .Values.extraCAs }}
+{{- range $key, $value := .Values.privateCAs }}
   {{ $key }}: {{ $value | quote }}
 {{- end }}
 {{- else }}

--- a/templates/kotsadm-deployment.yaml
+++ b/templates/kotsadm-deployment.yaml
@@ -118,7 +118,7 @@ spec:
         - mountPath: /tmp
           name: tmp
         - mountPath: /certs
-          name: kotsadm-extra-ca
+          name: kotsadm-private-cas
       initContainers:
       - args:
         - plan
@@ -209,5 +209,5 @@ spec:
       - emptyDir: {}
         name: tmp
       - configmap:
-          name: kotsadm-extra-ca
-        name: kotsadm-extra-ca
+          name: kotsadm-private-cas
+        name: kotsadm-private-cas

--- a/values.yaml.tmpl
+++ b/values.yaml.tmpl
@@ -111,4 +111,4 @@ kurlProxy:
   enabled: false
   targetPort: 8800
 
-extraCAs: {}
+privateCAs: {}


### PR DESCRIPTION
following comments on a previous prs we are defaulting to private-cas instead of extra-cas.