### PR TITLE
bug: fix config map entry on deployment

### DIFF
--- a/templates/kotsadm-deployment.yaml
+++ b/templates/kotsadm-deployment.yaml
@@ -215,7 +215,7 @@ spec:
       - emptyDir: {}
         name: tmp
 {{- if .Values.privateCAs.enabled }}
-      - configmap:
+      - configMap:
           name: "{{ .Values.privateCAs.configmapName }}"
           optional: true
         name: kotsadm-private-cas


### PR DESCRIPTION
this must be `configMap`, when manually editing the deployment and adding a `configmap` entry the api reports the following error:

```
decoding error: unknown field "spec.template.spec.volumes[3].configmap"
```