### PR TITLE
feat(customdomains): remove support bundle uri

### DIFF
--- a/troubleshoot/embedded-cluster-support-bundle.yaml
+++ b/troubleshoot/embedded-cluster-support-bundle.yaml
@@ -7,7 +7,8 @@ metadata:
     kots.io/kotsadm: "true"
     troubleshoot.io/kind: support-bundle
 spec:
-  uri: https://raw.githubusercontent.com/replicatedhq/kots-helm/main/troubleshoot/embedded-cluster-support-bundle.yaml
+  # NOTE: This is commented out until we have a decision on how to handle this with custom domains.
+  # uri: https://raw.githubusercontent.com/replicatedhq/kots-helm/main/troubleshoot/embedded-cluster-support-bundle.yaml
   collectors:
   - logs:
       name: podlogs/kotsadm


### PR DESCRIPTION
Do not make requests to anything other than custom domains. We will circle back and add this back once we figure out how to use the custom domain here.