### PR TITLE
fix: add hook-delete-policy before-hook-creation

### DIFF
--- a/templates/keep-resources-hook.yaml
+++ b/templates/keep-resources-hook.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-upgrade
     helm.sh/hook-weight: "2"
-    helm.sh/hook-delete-policy: hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     {{- include "admin-console.labels" . | nindent 4 }}
 spec:

--- a/templates/migrate-pvc-hook.yaml
+++ b/templates/migrate-pvc-hook.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-upgrade
     helm.sh/hook-weight: "1"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     {{- include "admin-console.labels" . | nindent 4 }}
 spec:

--- a/templates/migrate-s3-hook.yaml
+++ b/templates/migrate-s3-hook.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-upgrade
     helm.sh/hook-weight: "1"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     {{- include "admin-console.labels" . | nindent 4 }}
 spec:


### PR DESCRIPTION
If a hook fails or a helm operation exits before success the hook job will not be deleted. This change makes automation of helm charts more resilient as subsequent attempts will delete the hook.