### PR TITLE
fix: kotsadm deployment strategy recreate

### DIFF
--- a/templates/kotsadm-deployment.yaml
+++ b/templates/kotsadm-deployment.yaml
@@ -9,7 +9,7 @@ spec:
   selector:
     matchLabels:
       app: kotsadm
-  updateStrategy:
+  strategy:
     type: Recreate
   template:
     metadata:

--- a/templates/kotsadm-deployment.yaml
+++ b/templates/kotsadm-deployment.yaml
@@ -9,6 +9,8 @@ spec:
   selector:
     matchLabels:
       app: kotsadm
+  updateStrategy:
+    type: Recreate
   template:
     metadata:
       annotations:


### PR DESCRIPTION
Two kots pods should not be running at the same time. This is causing kots to serve the old ui after an update.