### PR TITLE
feat: Add support for extraVolumes and host CA bundle integration

### DIFF
--- a/templates/kotsadm-deployment.yaml
+++ b/templates/kotsadm-deployment.yaml
@@ -105,12 +105,6 @@ spec:
 {{- end }}
         - name: DISABLE_OUTBOUND_CONNECTIONS
           value: {{ .Values.isAirgap | quote }}
-{{- if .Values.privateCAs.enabled }}
-        - name: SSL_CERT_DIR
-          value: /certs
-        - name: SSL_CERT_CONFIGMAP
-          value: "{{ .Values.privateCAs.configmapName }}"
-{{- end }}
         image: {{ .Values.images.kotsadm }}
         imagePullPolicy: IfNotPresent
         name: kotsadm
@@ -147,9 +141,8 @@ spec:
           name: embedded-cluster-k0s-dir
           readOnly: true
 {{- end }}
-{{- if .Values.privateCAs.enabled }}
-        - mountPath: /certs
-          name: kotsadm-private-cas
+{{- if .Values.extraVolumeMounts }}
+        {{- toYaml .Values.extraVolumeMounts | nindent 8 }}
 {{- end }}
       initContainers:
       - args:
@@ -252,9 +245,6 @@ spec:
           path: {{ .Values.embeddedClusterK0sDir }}
           type: Directory
 {{- end }}
-{{- if .Values.privateCAs.enabled }}
-      - configMap:
-          name: "{{ .Values.privateCAs.configmapName }}"
-          optional: true
-        name: kotsadm-private-cas
+{{- if .Values.extraVolumes }}
+      {{- toYaml .Values.extraVolumes | nindent 6 }}
 {{- end }}

--- a/templates/kotsadm-deployment.yaml
+++ b/templates/kotsadm-deployment.yaml
@@ -105,6 +105,12 @@ spec:
 {{- end }}
         - name: DISABLE_OUTBOUND_CONNECTIONS
           value: {{ .Values.isAirgap | quote }}
+{{- if .Values.privateCAs.enabled }}
+        - name: SSL_CERT_DIR
+          value: /certs
+        - name: SSL_CERT_CONFIGMAP
+          value: "{{ .Values.privateCAs.configmapName }}"
+{{- end }}
         image: {{ .Values.images.kotsadm }}
         imagePullPolicy: IfNotPresent
         name: kotsadm
@@ -140,6 +146,10 @@ spec:
         - mountPath: {{ .Values.embeddedClusterK0sDir }}
           name: embedded-cluster-k0s-dir
           readOnly: true
+{{- end }}
+{{- if .Values.privateCAs.enabled }}
+        - mountPath: /certs
+          name: kotsadm-private-cas
 {{- end }}
 {{- if .Values.extraVolumeMounts }}
         {{- toYaml .Values.extraVolumeMounts | nindent 8 }}
@@ -244,6 +254,12 @@ spec:
         hostPath:
           path: {{ .Values.embeddedClusterK0sDir }}
           type: Directory
+{{- end }}
+{{- if .Values.privateCAs.enabled }}
+      - configMap:
+          name: "{{ .Values.privateCAs.configmapName }}"
+          optional: true
+        name: kotsadm-private-cas
 {{- end }}
 {{- if .Values.extraVolumes }}
       {{- toYaml .Values.extraVolumes | nindent 6 }}

--- a/values.yaml.tmpl
+++ b/values.yaml.tmpl
@@ -132,3 +132,7 @@ affinity:
 kurlProxy:
   enabled: false
   targetPort: 8800
+
+privateCAs:
+  enabled: false
+  configmapName: ""

--- a/values.yaml.tmpl
+++ b/values.yaml.tmpl
@@ -77,6 +77,18 @@ extraEnv: []
 #  - name: HTTP_PROXY
 #    value: http://proxy.example.com
 
+# Additional volumes to add to the kotsadm deployment
+extraVolumes: []
+# - name: host-ca-bundle
+#   hostPath:
+#     path: /etc/ssl/certs/ca-certificates.crt
+#     type: FileOrCreate
+
+# Additional volumeMounts to add to the kotsadm container
+extraVolumeMounts: []
+# - name: host-ca-bundle
+#   mountPath: /certs/ca-certificates.crt
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
@@ -120,7 +132,3 @@ affinity:
 kurlProxy:
   enabled: false
   targetPort: 8800
-
-privateCAs:
-  enabled: false
-  configmapName: ""


### PR DESCRIPTION
This PR adds support for adding custom volumes to the kotsadm deployment. 

* Adds extraVolumes and extraVolumeMounts fields to values.yaml.tmpl, allowing users to define custom volumes and mounts
* Updates the kotsadm-deployment.yaml template to render the custom volumes and mounts