### PR TITLE
fix(chart): release to staging registry on prod tag

### DIFF
--- a/.github/workflows/publish-production.yaml
+++ b/.github/workflows/publish-production.yaml
@@ -2,48 +2,76 @@ name: publish-production
 on:
   push:
     tags:
-    - 'v[0-9]+.[0-9]+.[0-9]+'
-    - 'v[0-9]+.[0-9]+.[0-9]+\-build\.[0-9]+'
+      - "v[0-9]+.[0-9]+.[0-9]+"
+      - 'v[0-9]+.[0-9]+.[0-9]+\-build\.[0-9]+'
 
 jobs:
   package-and-publish:
-    runs-on: 'ubuntu-24.04'
+    runs-on: "ubuntu-24.04"
     steps:
-    - name: Get tag
-      id: tag
-      uses: dawidd6/action-get-tag@v1
-      with:
-        strip_v: true
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Install Helm
-      uses: azure/setup-helm@v1
-      with:
-        version: v3.8.1
-    - name: Run Package and Publish
-      env: 
-        HELM_USER: ${{secrets.KOTS_HELM_USER_PROD}}
-        HELM_PASS: ${{secrets.KOTS_HELM_PASS_PROD}}
-        CHART_VERSION: ${{steps.tag.outputs.tag}}
-      run: |
-        export KOTS_VERSION=${CHART_VERSION%-*}
-        export KOTS_TAG=v${KOTS_VERSION}
-        export KOTSADM_REGISTRY=kotsadm # docker.io is implicit
+      - name: Get tag
+        id: tag
+        uses: dawidd6/action-get-tag@v1
+        with:
+          strip_v: true
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.8.1
+      - name: Package the Helm chart
+        env:
+          CHART_VERSION: ${{steps.tag.outputs.tag}}
+        run: |
+          export KOTS_VERSION=${CHART_VERSION%-*}
+          export KOTS_TAG=v${KOTS_VERSION}
+          export KOTSADM_REGISTRY=kotsadm # docker.io is implicit
 
-        export LATEST_KOTS_TAG=`curl https://api.github.com/repos/replicatedhq/kots/releases/latest | jq -r .tag_name`
-        if [[ "$KOTS_TAG" != "$LATEST_KOTS_TAG" ]]; then
-          echo "Latest KOTS tag is ${LATEST_KOTS_TAG}, but this tag is ${KOTS_TAG}"
-          exit -1
-        fi
+          export LATEST_KOTS_TAG=`curl https://api.github.com/repos/replicatedhq/kots/releases/latest | jq -r .tag_name`
+          if [[ "$KOTS_TAG" != "$LATEST_KOTS_TAG" ]]; then
+            echo "Latest KOTS tag is ${LATEST_KOTS_TAG}, but this tag is ${KOTS_TAG}"
+            exit -1
+          fi
 
-        curl -O -L https://raw.githubusercontent.com/replicatedhq/kots/${KOTS_TAG}/.image.env
-        export $(cat .image.env | sed 's/#.*//g' | xargs)
+          curl -O -L https://raw.githubusercontent.com/replicatedhq/kots/${KOTS_TAG}/.image.env
+          export $(cat .image.env | sed 's/#.*//g' | xargs)
 
-        envsubst < Chart.yaml.tmpl > Chart.yaml
-        envsubst < values.yaml.tmpl > values.yaml
-        rm -f *.tmpl
+          # Generate Helm chart files from templates
+          envsubst < Chart.yaml.tmpl > Chart.yaml
+          envsubst < values.yaml.tmpl > values.yaml
+          rm -f *.tmpl
 
-        export CHART_NAME=`helm package . | rev | cut -d/ -f1 | rev`
-        echo pushing ${CHART_NAME} to production
-        helm registry login registry.replicated.com  --username $HELM_USER --password $HELM_PASS
-        helm push $CHART_NAME oci://registry.replicated.com/library
+          # Package the chart
+          export CHART_NAME=`helm package . | rev | cut -d/ -f1 | rev`
+          echo "CHART_NAME=${CHART_NAME}" >> $GITHUB_ENV
+
+      - name: Publish to staging registry
+        env:
+          HELM_USER: ${{secrets.KOTS_HELM_USER_STAGING}}
+          HELM_PASS: ${{secrets.KOTS_HELM_PASS_STAGING}}
+        run: |
+          echo "Publishing ${CHART_NAME} to staging registry"
+
+          # Login to registry
+          helm registry login registry.staging.replicated.com \
+            --username "$HELM_USER" \
+            --password "$HELM_PASS"
+
+          # Push the chart
+          helm push "$CHART_NAME" oci://registry.staging.replicated.com/library
+
+      - name: Publish to production registry
+        env:
+          HELM_USER: ${{secrets.KOTS_HELM_USER_PROD}}
+          HELM_PASS: ${{secrets.KOTS_HELM_PASS_PROD}}
+        run: |
+          echo "Publishing ${CHART_NAME} to production registry"
+
+          # Login to registry
+          helm registry login registry.replicated.com \
+            --username "$HELM_USER" \
+            --password "$HELM_PASS"
+
+          # Push the chart
+          helm push "$CHART_NAME" oci://registry.replicated.com/library


### PR DESCRIPTION
We've recently changed our release manifests in EC to start using the production OCI proxy directly. This requires us to have production releases of kots' helm chart in our staging registry too. See:
- https://github.com/replicatedhq/embedded-cluster/actions/runs/18115871527/job/51577377948?pr=2982#step:4:793
- https://github.com/replicatedhq/embedded-cluster/pull/2982

This PR changes the `publish-production` job to also publish to the staging registry.